### PR TITLE
FIX: all memory leaks removed

### DIFF
--- a/src/lib/amiws.h
+++ b/src/lib/amiws.h
@@ -126,6 +126,10 @@ struct amiws_conn {
   struct amiws_conn *next;  /*!< Pointer to next connection. */
 };
 
+int isExiting();
+
+void setExiting();
+
 /**
  * Initialize amiws with given configuration.
  * Will start listening for HTTP and WebSocket

--- a/src/lib/mongoose.c
+++ b/src/lib/mongoose.c
@@ -2272,6 +2272,27 @@ void mg_mgr_free(struct mg_mgr *m) {
     }
     MG_FREE(m->ifaces);
   }
+#if MG_ENABLE_SSL
+    FIPS_mode_set(0);
+    CRYPTO_set_locking_callback(NULL);
+    CRYPTO_set_id_callback(NULL);
+
+    ERR_remove_state(0);
+
+    SSL_COMP_free_compression_methods();
+
+    ENGINE_cleanup();
+
+    CONF_modules_free();
+    CONF_modules_unload(1);
+
+    COMP_zlib_cleanup();
+
+    ERR_free_strings();
+    EVP_cleanup();
+
+    CRYPTO_cleanup_all_ex_data();
+#endif
 }
 
 time_t mg_mgr_poll(struct mg_mgr *m, int timeout_ms) {


### PR DESCRIPTION
Before:
```
==1195== LEAK SUMMARY:
==1195==    definitely lost: 289,979,050 bytes in 515,186 blocks
==1195==    indirectly lost: 139,669,659 bytes in 6,663,902 blocks
==1195==      possibly lost: 482,308 bytes in 2,329 blocks
==1195==    still reachable: 35,972 bytes in 1,077 blocks
==1195==         suppressed: 0 bytes in 0 blocks
```

After:
```
==4031== HEAP SUMMARY:
==4031==     in use at exit: 0 bytes in 0 blocks
==4031==   total heap usage: 653,675 allocs, 653,675 frees, 57,641,387 bytes allocated
==4031==
==4031== All heap blocks were freed -- no leaks are possible
==4031==

```