### PR TITLE
FIX: memory context errors. Valgrind now is very happy.

### DIFF
--- a/src/lib/amiws.h
+++ b/src/lib/amiws.h
@@ -56,6 +56,7 @@
 
 /*! Macro to initilize configuration structure. */
 #define macro_init_conf(conf) conf = (struct amiws_config *) malloc(sizeof(struct amiws_config));\
+  memset(conf,0,sizeof(struct amiws_config)); \
   conf->log_level     = DEFAULT_LOG_LEVEL;    \
   conf->log_facility  = DEFAULT_LOG_FACILITY; \
   conf->ws_port       = DEFAULT_WEBSOCK_PORT; \
@@ -71,13 +72,15 @@
 
 /*! Macro to initilize AMI connection. */
 #define macro_init_conn(conn) conn = (struct amiws_conn *) malloc(sizeof(struct amiws_conn)); \
-  conn->port = 5038;      \
-  conn->address = NULL;   \
-  conn->name = NULL;      \
-  conn->host = NULL;      \
-  conn->username = NULL;  \
-  conn->secret = NULL;    \
-  conn->is_ssl = 0;       \
+  memset(conn,0,sizeof(struct amiws_conn)); \
+  conn->port = 5038;        \
+  conn->address = NULL;     \
+  conn->name = NULL;        \
+  conn->host = NULL;        \
+  conn->username = NULL;    \
+  conn->secret = NULL;      \
+  conn->is_ssl = 0;         \
+  conn->event_names = NULL; \
 
 
 /*!


### PR DESCRIPTION
^Camiws[29425]: Exiting application.
amiws[29425]: Stop amiws
amiws[29425]: Closed New Web Socket connection from 0.0.0.0:8000
==29425==
==29425== HEAP SUMMARY:
==29425==     in use at exit: 0 bytes in 0 blocks
==29425==   total heap usage: 709 allocs, 709 frees, 141,456 bytes allocated
==29425==
==29425== All heap blocks were freed -- no leaks are possible
==29425==
==29425== For lists of detected and suppressed errors, rerun with: -s
==29425== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
